### PR TITLE
Testes E2E (Preferências)

### DIFF
--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -1,6 +1,10 @@
 name: Cypress Tests
 
-on: push
+on: 
+  push:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   cypress-run:

--- a/cypress/e2e/preferences.cy.ts
+++ b/cypress/e2e/preferences.cy.ts
@@ -1,0 +1,43 @@
+describe('Preferences', () => {
+  beforeEach(() => {
+    cy.visit('/')
+  })
+
+  it('should be able to change the theme', () => {
+    cy.get('#banner').should(
+      'have.css',
+      'background-color',
+      'rgb(248, 113, 113)',
+    )
+
+    cy.get("button[data-testid='open-settings']").click()
+    cy.get("div[role='tablist'] button").eq(0).click()
+    cy.get("div[role='menuitem']").first().click()
+
+    cy.get('#banner').should(
+      'have.css',
+      'background-color',
+      'rgb(148, 163, 184)',
+    )
+  })
+
+  it('should be able to change the logo', () => {
+    cy.get("span[data-testid='logo']").should('have.text', '🍎')
+
+    cy.get("button[data-testid='open-settings']").click()
+    cy.get("div[role='tablist'] button").eq(1).click()
+    cy.get("button[aria-label='grin']").click()
+
+    cy.get("span[data-testid='logo']").should('have.text', '😁')
+  })
+
+  it('should be able to change the language', () => {
+    cy.get('input').should('have.attr', 'placeholder', 'Descreva sua atividade')
+
+    cy.get("button[data-testid='open-settings']").click()
+    cy.get("div[role='tablist'] button").eq(2).click()
+    cy.get("label[for='english']").click()
+
+    cy.get('input').should('have.attr', 'placeholder', 'Describe your activity')
+  })
+})

--- a/cypress/e2e/preferences.cy.ts
+++ b/cypress/e2e/preferences.cy.ts
@@ -32,12 +32,14 @@ describe('Preferences', () => {
   })
 
   it('should be able to change the language', () => {
+    cy.get("button[data-testid='open-settings']").click()
+
+    cy.get("div[role='tablist'] button").eq(2).click()
+    cy.get("label[for='portuguese']").click()
     cy.get('input').should('have.attr', 'placeholder', 'Descreva sua atividade')
 
-    cy.get("button[data-testid='open-settings']").click()
     cy.get("div[role='tablist'] button").eq(2).click()
     cy.get("label[for='english']").click()
-
     cy.get('input').should('have.attr', 'placeholder', 'Describe your activity')
   })
 })

--- a/cypress/e2e/todos.cy.ts
+++ b/cypress/e2e/todos.cy.ts
@@ -25,7 +25,7 @@ describe('Todos', () => {
 
     cy.get('#todo-list li')
       .first()
-      .find('button[aria-label="Remover atividade"]')
+      .find('button[data-testid="remove-button"]')
       .click()
 
     cy.get('#todo-list li').should('have.length', 1)

--- a/src/components/banner/index.tsx
+++ b/src/components/banner/index.tsx
@@ -4,10 +4,10 @@ import styles from './styles.module.scss'
 
 export function Banner() {
   return (
-    <div className={styles.banner}>
+    <header id="banner" className={styles.banner}>
       <Container className={styles.container}>
         <Settings />
       </Container>
-    </div>
+    </header>
   )
 }

--- a/src/components/logo/index.tsx
+++ b/src/components/logo/index.tsx
@@ -8,7 +8,9 @@ export function Logo() {
   return (
     <Container>
       <div className={styles.logoContainer}>
-        <span className={styles.logo}>{icon}</span>
+        <span data-testid="logo" className={styles.logo}>
+          {icon}
+        </span>
       </div>
     </Container>
   )

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -23,7 +23,7 @@ export function Settings() {
   return (
     <Dropdown.Root>
       <Dropdown.Trigger>
-        <button className={styles.trigger}>
+        <button data-testid="open-settings" className={styles.trigger}>
           <SettingsIcon size={24} />
         </button>
       </Dropdown.Trigger>

--- a/src/components/settings/language-selector/index.tsx
+++ b/src/components/settings/language-selector/index.tsx
@@ -7,7 +7,7 @@ import { FlagUS } from '../../flags/flag-us'
 import styles from './styles.module.scss'
 
 export function LanguageSelector() {
-  const { i18n } = useTranslation()
+  const { i18n, t } = useTranslation()
   const [selectedLanguage, setSelectedLanguage] = useState(i18n.language)
 
   function handleLanguageChange(value: string) {
@@ -20,7 +20,7 @@ export function LanguageSelector() {
       className={styles.radioGroupRoot}
       value={selectedLanguage}
       onValueChange={handleLanguageChange}
-      aria-label="Selecione o idioma do aplicativo"
+      aria-label={t('languageSelectorAriaLabel')}
     >
       <div className={styles.radioGroupContent}>
         <RadioGroup.Item

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,5 +1,7 @@
 {
-  "placeholder": "Describe your activity",
+  "inputPlaceholder": "Describe your activity",
+  "removeTodoAriaLabel": "Remove Task",
+  "languageSelectorAriaLabel": "Select the application language",
   "settings": {
     "colors": "Colors",
     "icons": "Icons",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -1,5 +1,7 @@
 {
-  "placeholder": "Descreva sua atividade",
+  "inputPlaceholder": "Descreva sua atividade",
+  "removeTodoAriaLabel": "Remover Tarefa",
+  "languageSelectorAriaLabel": "Selecione o idioma do aplicativo",
   "settings": {
     "colors": "Cores",
     "icons": "Ícones",

--- a/src/pages/home/add-todo-form/index.tsx
+++ b/src/pages/home/add-todo-form/index.tsx
@@ -56,7 +56,7 @@ export function AddTodoForm() {
 
           <input
             type="text"
-            placeholder={t('placeholder')}
+            placeholder={t('inputPlaceholder')}
             {...register('description')}
           />
         </div>

--- a/src/pages/home/todo-item/index.tsx
+++ b/src/pages/home/todo-item/index.tsx
@@ -2,6 +2,7 @@ import * as Checkbox from '@radix-ui/react-checkbox'
 import classNames from 'classnames'
 import { CheckIcon, TrashIcon } from 'lucide-react'
 import { type ComponentProps } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { type Todo } from '../../../interfaces/todo'
 import { useTodos } from '../../../store/todos'
@@ -12,6 +13,8 @@ interface TodoItemProps extends ComponentProps<'li'> {
 }
 
 export function TodoItem({ data, ...props }: TodoItemProps) {
+  const { t } = useTranslation()
+
   const toggleTodo = useTodos(state => state.toggleTodo)
   const removeTodo = useTodos(state => state.removeTodo)
 
@@ -50,7 +53,8 @@ export function TodoItem({ data, ...props }: TodoItemProps) {
         type="button"
         onClick={handleRemoveTodo}
         className={styles.deleteButton}
-        aria-label="Remover atividade"
+        data-testid="remove-button"
+        aria-label={t('removeTodoAriaLabel')}
       >
         <TrashIcon size={20} />
       </button>


### PR DESCRIPTION
## Resumo
Testes E2E no Cypress para o menu de preferências do usuário.

![Captura de tela de 2024-03-21 21-22-13](https://github.com/ClodoaldoDantas/simple-todo/assets/32376905/81c7f591-6f5d-4700-bebb-7ece99ade9ba)
